### PR TITLE
[add] prediction results return all algorithm's demand

### DIFF
--- a/pio-engine/src/main/scala/Algorithm.scala
+++ b/pio-engine/src/main/scala/Algorithm.scala
@@ -38,7 +38,7 @@ class Algorithm(val ap: AlgorithmParams)
 
   def predict(model: Model, query: Query): PredictedResult = {
     val label : Double = model.predict(query)
-    new PredictedResult(label)
+    new PredictedResult(label, Map("algRegression" -> label))
   }
 }
 

--- a/pio-engine/src/main/scala/AlgorithmGBTree.scala
+++ b/pio-engine/src/main/scala/AlgorithmGBTree.scala
@@ -34,7 +34,7 @@ class AlgorithmGBTree(val ap: GBTreeParams)
 
   override def predict(model: ModelGBTree, query: Query): PredictedResult = {
     val label : Double = model.predict(query)
-    new PredictedResult(label)
+    new PredictedResult(label, Map("algGBTree" -> label))
   }
 }
 

--- a/pio-engine/src/main/scala/Engine.scala
+++ b/pio-engine/src/main/scala/Engine.scala
@@ -19,7 +19,8 @@ class Query(
 ) extends Serializable
 
 class PredictedResult(
-                       val demand: Double
+                       val demand: Double,
+                       val algorithms: Map[String, Double]
                      ) extends Serializable
 
 class ActualResult(

--- a/pio-engine/src/main/scala/RidgeRegressionAlgorithm.scala
+++ b/pio-engine/src/main/scala/RidgeRegressionAlgorithm.scala
@@ -47,7 +47,7 @@ class RidgeRegressionAlgorithm(val ap: RidgeRegressionParams)
 
   def predict(model: RidgeRegressionAlgorithmModel, query: Query): PredictedResult = {
     val label : Double = model.predict(query)
-    new PredictedResult(label)
+    new PredictedResult(label, Map("ridgeRegression" -> label))
   }
 }
 

--- a/pio-engine/src/main/scala/Serving.scala
+++ b/pio-engine/src/main/scala/Serving.scala
@@ -6,15 +6,18 @@ class Serving extends LServing[Query, PredictedResult] {
 
   override def serve(query: Query,
                      predictedResults: Seq[PredictedResult]): PredictedResult = {
-    println(predictedResults.length)
-    println(predictedResults.head.demand)
-    println(predictedResults.last.demand)
-    var sumResult:Double = 0.0
-    predictedResults.foreach(sumResult += _.demand)
 
-    //val sumResult: Double = predictedResults.foldLeft(0.0){( acc: Double, pred: PredictedResult) => acc + pred.demand}
-    println(sumResult)
-    val meanResult: Double = sumResult / predictedResults.length
-    new PredictedResult(meanResult)
+    val algorithms : Map[String, Double] = predictedResults.foldLeft(Map.empty[String, Double]) {
+      (acc: Map[String, Double], pred: PredictedResult) =>
+        (acc.keySet ++ pred.algorithms.keySet).map(i=>
+          (i, acc.getOrElse(i, 0.0) + pred.algorithms.getOrElse(i,0.0))).toMap
+    }
+
+    val demand = predictedResults.foldLeft(0.0) {
+      (acc : Double, pred: PredictedResult) =>
+        acc + pred.demand
+    }
+
+    new PredictedResult(demand / predictedResults.length, algorithms)
   }
 }


### PR DESCRIPTION
working with @Hw-chen to modify the demand results to confirm the following format:

```
{
"demand" : 123.0,
"algorithms": {
    "algGBTree":1.0,
    "algRegression":0.9997697368114319
  }
}
```